### PR TITLE
Change addressing from `u64` to `usize`

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -6,9 +6,6 @@
   * Think of some place for "notes" - eg, if a transformation has a comment or warning or something, it should have a place to be seen
   * Look at the formats in https://github.com/wader/fq/
 
-* Major / annoying cleanup
-  * Make bumpyvectors use usize instead of u64
-
 * Nested bumpy vectors
   * Print structs and such more nicely
   * Comments on any field?

--- a/generic-number/src/helpers/context.rs
+++ b/generic-number/src/helpers/context.rs
@@ -18,7 +18,7 @@ pub const MAX_UTF16_WORDS: usize = 2;
 #[derive(Debug, Clone, Copy)]
 pub struct Context<'a> {
     v: &'a Vec<u8>,
-    position: u64,
+    position: usize,
     //c: Cursor<&'a Vec<u8>>,
 }
 
@@ -38,7 +38,7 @@ impl<'a> Context<'a> {
     ///
     /// Cannot fail, even if the Vec is empty or if the position is crazy. Those
     /// are checked when using the cursor, not while creating it.
-    pub fn new_at(v: &'a Vec<u8>, position: u64) -> Self {
+    pub fn new_at(v: &'a Vec<u8>, position: usize) -> Self {
         //let mut c = Cursor::new(v);
         //c.set_position(position);
 
@@ -56,7 +56,7 @@ impl<'a> Context<'a> {
     /// the data - just a reference.
     fn cursor(self) -> Cursor<&'a Vec<u8>> {
         let mut cursor = Cursor::new(self.v);
-        cursor.set_position(self.position);
+        cursor.set_position(self.position as u64);
 
         cursor
     }
@@ -65,7 +65,7 @@ impl<'a> Context<'a> {
     ///
     /// I found myself doing a clone-then-set-position operation a bunch, so
     /// this simplifies it.
-    pub fn at(self, new_position: u64) -> Self {
+    pub fn at(self, new_position: usize) -> Self {
         // Since this has the Copy trait, we can copy it super easy
         let mut c = self;
         c.position = new_position;
@@ -74,7 +74,7 @@ impl<'a> Context<'a> {
     }
 
     /// Get the current position.
-    pub fn position(self) -> u64 {
+    pub fn position(self) -> usize {
         self.position
     }
 
@@ -313,7 +313,7 @@ impl<'a> Context<'a> {
 
     /// Get a [`u8`] slice starting at the current `position`
     pub fn as_slice(self) -> &'a [u8] {
-        &self.v[(self.position as usize)..]
+        &self.v[(self.position)..]
     }
 }
 

--- a/generic-number/src/integer.rs
+++ b/generic-number/src/integer.rs
@@ -105,6 +105,8 @@ impl Integer {
             Self::U8(v)        => Ok(v as usize),
             Self::U16(v)       => Ok(v as usize),
             Self::U32(v)       => Ok(v as usize),
+
+            // These may be unreachable - it depends if can_be_usize() passes
             Self::U64(v)       => Ok(v as usize),
             Self::U128(v)      => Ok(v as usize),
 
@@ -152,6 +154,8 @@ impl Integer {
             Self::I8(v)        => Ok(v as isize),
             Self::I16(v)       => Ok(v as isize),
             Self::I32(v)       => Ok(v as isize),
+
+            // These may be unreachable - it depends if can_be_isize() passes
             Self::I64(v)       => Ok(v as isize),
             Self::I128(v)      => Ok(v as isize),
         }

--- a/h2datatype/src/alignment.rs
+++ b/h2datatype/src/alignment.rs
@@ -22,14 +22,14 @@ pub enum Alignment {
     /// Each field is padded until its length is a multiple of the padding
     /// Length.. so 0..1 aligned to 4 will be 0..4, and 1..2 aligned to 4 will
     /// be 1..5
-    Loose(u64),
+    Loose(usize),
 
     /// Only pad after, but error out if the start isn't aligned.
-    Strict(u64),
+    Strict(usize),
 }
 
 impl Alignment {
-    fn round_up(number: u64, multiple: u64) -> u64 {
+    fn round_up(number: usize, multiple: usize) -> usize {
         if multiple == 0 {
             return number;
         }
@@ -42,7 +42,7 @@ impl Alignment {
         number - remainder + multiple
     }
 
-    pub fn align(self, range: Range<u64>) -> SimpleResult<Range<u64>> {
+    pub fn align(self, range: Range<usize>) -> SimpleResult<Range<usize>> {
         if range.end < range.start {
             bail!("Range ends before it starts");
         }
@@ -77,7 +77,7 @@ mod tests {
 
     #[test]
     fn test_none() -> SimpleResult<()> {
-        let tests: Vec<(Range<u64>, Range<u64>)> = vec![
+        let tests: Vec<(Range<usize>, Range<usize>)> = vec![
             //       value       expected
             (         0..0,          0..0),
             (        0..10,         0..10),
@@ -95,7 +95,7 @@ mod tests {
 
     #[test]
     fn test_loose() -> SimpleResult<()> {
-        let tests: Vec<(Range<u64>, u64, Range<u64>)> = vec![
+        let tests: Vec<(Range<usize>, usize, Range<usize>)> = vec![
             //  value  multiple  expected
             (    0..0,        0,     0..0),
             (    0..0,        4,     0..0),
@@ -117,7 +117,7 @@ mod tests {
 
     #[test]
     fn test_strict() -> SimpleResult<()> {
-        let good_tests: Vec<(Range<u64>, u64, Range<u64>)> = vec![
+        let good_tests: Vec<(Range<usize>, usize, Range<usize>)> = vec![
             //      value  multiple  expected
             (    0..0,        0,         0..0),
             (    0..1,        4,         0..4),
@@ -134,7 +134,7 @@ mod tests {
             assert_eq!(expected, Alignment::Strict(multiple).align(value)?);
         }
 
-        let bad_tests: Vec<(Range<u64>, u64)> = vec![
+        let bad_tests: Vec<(Range<usize>, usize)> = vec![
             //   value      multiple
             (    2..3,            4),
             (    1..1,            4),

--- a/h2datatype/src/composite/h2array.rs
+++ b/h2datatype/src/composite/h2array.rs
@@ -17,11 +17,11 @@ use crate::{Alignment, H2Type, H2Types, H2TypeTrait};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct H2Array {
     field_type: Box<H2Type>,
-    length: u64,
+    length: usize,
 }
 
 impl H2Array {
-    pub fn new_aligned(alignment: Alignment, length: u64, field_type: H2Type) -> SimpleResult<H2Type> {
+    pub fn new_aligned(alignment: Alignment, length: usize, field_type: H2Type) -> SimpleResult<H2Type> {
         if length == 0 {
             bail!("Arrays must be at least one element long");
         }
@@ -32,7 +32,7 @@ impl H2Array {
         })))
     }
 
-    pub fn new(length: u64, field_type: H2Type) -> SimpleResult<H2Type> {
+    pub fn new(length: usize, field_type: H2Type) -> SimpleResult<H2Type> {
         Self::new_aligned(Alignment::None, length, field_type)
     }
 }

--- a/h2datatype/src/h2type.rs
+++ b/h2datatype/src/h2type.rs
@@ -114,28 +114,28 @@ impl H2Type {
     /// Note that if the type has children (such as a
     /// [`crate::composite::H2Array`], the alignment on THAT is
     /// included since that's part of the actual object.
-    pub fn base_size(&self, context: Context) -> SimpleResult<u64> {
+    pub fn base_size(&self, context: Context) -> SimpleResult<usize> {
         self.field_type().base_size(context)
     }
 
     /// Get the size of the field, including the alignment.
-    pub fn aligned_size(&self, context: Context) -> SimpleResult<u64> {
+    pub fn aligned_size(&self, context: Context) -> SimpleResult<usize> {
         self.field_type().aligned_size(context, self.alignment)
     }
 
-    /// Get the [`Range<u64>`] that the type will cover, starting at the
+    /// Get the [`Range<usize>`] that the type will cover, starting at the
     /// given [`Context`], if it can be known, without adding padding.
-    pub fn actual_range(&self, context: Context) -> SimpleResult<Range<u64>> {
+    pub fn actual_range(&self, context: Context) -> SimpleResult<Range<usize>> {
         self.field_type().range(context, Alignment::None)
     }
 
-    /// Get the [`Range<u64>`] that the type will cover, with padding.
-    pub fn aligned_range(&self, context: Context) -> SimpleResult<Range<u64>> {
+    /// Get the [`Range<usize>`] that the type will cover, with padding.
+    pub fn aligned_range(&self, context: Context) -> SimpleResult<Range<usize>> {
         self.field_type().range(context, self.alignment)
     }
 
     /// Get *related* nodes - ie, other fields that a pointer points to
-    pub fn related(&self, context: Context) -> SimpleResult<Vec<(u64, H2Type)>> {
+    pub fn related(&self, context: Context) -> SimpleResult<Vec<(usize, H2Type)>> {
         self.field_type().related(context)
     }
 

--- a/h2datatype/src/h2typetrait.rs
+++ b/h2datatype/src/h2typetrait.rs
@@ -34,7 +34,7 @@ pub trait H2TypeTrait {
     ///
     /// Types without children - in general, [`crate::simple`]s - must also
     /// implement this. Without children, we can't tell.
-    fn base_size(&self, context: Context) -> SimpleResult<u64> {
+    fn base_size(&self, context: Context) -> SimpleResult<usize> {
         let children = self.children_with_range(context)?;
 
         let first_range = match children.first() {
@@ -54,7 +54,7 @@ pub trait H2TypeTrait {
     /// Get the aligned size.
     ///
     /// The default implementation is very likely fine for this.
-    fn aligned_size(&self, context: Context, alignment: Alignment) -> SimpleResult<u64> {
+    fn aligned_size(&self, context: Context, alignment: Alignment) -> SimpleResult<usize> {
         let range = self.range(context, alignment)?;
 
         Ok(range.end - range.start)
@@ -66,7 +66,7 @@ pub trait H2TypeTrait {
     /// The default implementation is very likely good. This is only
     /// implemented as a trait function because other trait functions (such as
     /// [`#resolve`]) use it.
-    fn range(&self, context: Context, alignment: Alignment) -> SimpleResult<Range<u64>> {
+    fn range(&self, context: Context, alignment: Alignment) -> SimpleResult<Range<usize>> {
         // Get the start and end
         let start = context.position();
         let end   = start + self.base_size(context)?;
@@ -82,7 +82,7 @@ pub trait H2TypeTrait {
     fn to_display(&self, context: Context) -> SimpleResult<String>;
 
     /// Get "related" values - ie, what a pointer points to.
-    fn related(&self, _context: Context) -> SimpleResult<Vec<(u64, H2Type)>> {
+    fn related(&self, _context: Context) -> SimpleResult<Vec<(usize, H2Type)>> {
         Ok(vec![])
     }
 
@@ -113,7 +113,7 @@ pub trait H2TypeTrait {
     /// children are consecutive, adjacent, and make up the full parent type.
     /// As long as that's the case, the default implementation will work just
     /// fine.
-    fn children_with_range(&self, context: Context) -> SimpleResult<Vec<(Range<u64>, Option<String>, H2Type)>> {
+    fn children_with_range(&self, context: Context) -> SimpleResult<Vec<(Range<usize>, Option<String>, H2Type)>> {
         let mut child_context = context;
 
         self.children(context)?.into_iter().map(|(name, child)| {

--- a/h2datatype/src/resolved_type.rs
+++ b/h2datatype/src/resolved_type.rs
@@ -14,14 +14,14 @@ use generic_number::{Integer, Float, Character};
 /// unexpected data).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ResolvedType {
-    pub actual_range: Range<u64>,
-    pub aligned_range: Range<u64>,
+    pub actual_range: Range<usize>,
+    pub aligned_range: Range<usize>,
 
     pub field_name: Option<String>,
     pub display: String,
 
     pub children: Vec<ResolvedType>,
-    pub related: Vec<(u64, H2Type)>,
+    pub related: Vec<(usize, H2Type)>,
 
     pub as_string:    Option<String>,
     pub as_integer:   Option<Integer>,
@@ -30,11 +30,11 @@ pub struct ResolvedType {
 }
 
 impl ResolvedType {
-    pub fn base_size(&self) -> u64 {
+    pub fn base_size(&self) -> usize {
         self.actual_range.end - self.actual_range.start
     }
 
-    pub fn aligned_size(&self) -> u64 {
+    pub fn aligned_size(&self) -> usize {
         self.aligned_range.end - self.aligned_range.start
     }
 }

--- a/h2datatype/src/simple/h2bitmask.rs
+++ b/h2datatype/src/simple/h2bitmask.rs
@@ -52,8 +52,8 @@ impl H2Bitmask {
 }
 
 impl H2TypeTrait for H2Bitmask {
-    fn base_size(&self, _context: Context) -> SimpleResult<u64> {
-        Ok(self.reader.size() as u64)
+    fn base_size(&self, _context: Context) -> SimpleResult<usize> {
+        Ok(self.reader.size())
     }
 
     fn to_display(&self, context: Context) -> SimpleResult<String> {

--- a/h2datatype/src/simple/h2blob.rs
+++ b/h2datatype/src/simple/h2blob.rs
@@ -13,11 +13,11 @@ use crate::{H2Type, H2Types, H2TypeTrait, Alignment};
 /// types.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct H2Blob {
-    length: u64,
+    length: usize,
 }
 
 impl H2Blob {
-    pub fn new_aligned(alignment: Alignment, length_in_bytes: u64) -> SimpleResult<H2Type> {
+    pub fn new_aligned(alignment: Alignment, length_in_bytes: usize) -> SimpleResult<H2Type> {
         if length_in_bytes == 0 {
             bail!("Length must be at least 1 character long");
         }
@@ -27,13 +27,13 @@ impl H2Blob {
         })))
     }
 
-    pub fn new(length_in_bytes: u64) -> SimpleResult<H2Type> {
+    pub fn new(length_in_bytes: usize) -> SimpleResult<H2Type> {
         Self::new_aligned(Alignment::None, length_in_bytes)
     }
 }
 
 impl H2TypeTrait for H2Blob {
-    fn base_size(&self, _context: Context) -> SimpleResult<u64> {
+    fn base_size(&self, _context: Context) -> SimpleResult<usize> {
         Ok(self.length)
     }
 

--- a/h2datatype/src/simple/h2enum.rs
+++ b/h2datatype/src/simple/h2enum.rs
@@ -24,7 +24,7 @@ pub struct H2Enum {
 impl H2Enum {
     pub fn new_aligned(alignment: Alignment, reader: IntegerReader, enum_type: &str) -> SimpleResult<H2Type> {
         if !reader.can_be_usize() {
-            bail!("Enum types must be compatible with u64 values");
+            bail!("Enum types must be compatible with usize values");
         }
 
         // Make sure the enum type exists
@@ -54,13 +54,13 @@ impl H2Enum {
 }
 
 impl H2TypeTrait for H2Enum {
-    fn base_size(&self, _context: Context) -> SimpleResult<u64> {
-        Ok(self.reader.size() as u64)
+    fn base_size(&self, _context: Context) -> SimpleResult<usize> {
+        Ok(self.reader.size())
     }
 
     fn to_display(&self, context: Context) -> SimpleResult<String> {
-        let as_u64 = self.reader.read(context)?.as_usize()?;
-        self.render(as_u64)
+        let as_usize = self.reader.read(context)?.as_usize()?;
+        self.render(as_usize)
     }
 
     fn can_be_string(&self) -> bool {

--- a/h2datatype/src/simple/h2pointer.rs
+++ b/h2datatype/src/simple/h2pointer.rs
@@ -19,7 +19,6 @@
 
 //impl H2Pointer {
 //    pub fn new_aligned(alignment: Alignment, definition: IntegerReader, display: GenericFormatter, target_type: H2Type) -> H2Type {
-//        // TODO: Ensure the definition can be a u64
 //        H2Type::new(alignment, H2Types::H2Pointer(Self {
 //            definition: definition,
 //            display: display,
@@ -34,7 +33,6 @@
 
 //impl H2TypeTrait for H2Pointer {
 //    fn base_size(&self, offset: Offset) -> SimpleResult<u64> {
-//        // TODO: I'm not sure if using the static size here is really something I should care about, as opposed to just reading + checking
 //        match self.definition.size() {
 //            Some(v) => Ok(v as u64),
 //            None    => Ok(self.definition.read(offset.get_dynamic()?)?.size() as u64),

--- a/h2datatype/src/simple/h2uuid.rs
+++ b/h2datatype/src/simple/h2uuid.rs
@@ -28,7 +28,7 @@ impl H2UUID {
 }
 
 impl H2TypeTrait for H2UUID {
-    fn base_size(&self, _context: Context) -> SimpleResult<u64> {
+    fn base_size(&self, _context: Context) -> SimpleResult<usize> {
         Ok(16)
     }
 

--- a/h2datatype/src/simple/network/ipv4.rs
+++ b/h2datatype/src/simple/network/ipv4.rs
@@ -28,7 +28,7 @@ impl IPv4 {
 }
 
 impl H2TypeTrait for IPv4 {
-    fn base_size(&self, _context: Context) -> SimpleResult<u64> {
+    fn base_size(&self, _context: Context) -> SimpleResult<usize> {
         Ok(4)
     }
 

--- a/h2datatype/src/simple/network/ipv6.rs
+++ b/h2datatype/src/simple/network/ipv6.rs
@@ -28,7 +28,7 @@ impl IPv6 {
 }
 
 impl H2TypeTrait for IPv6 {
-    fn base_size(&self, _context: Context) -> SimpleResult<u64> {
+    fn base_size(&self, _context: Context) -> SimpleResult<usize> {
         Ok(16)
     }
 

--- a/h2datatype/src/simple/network/mac_address.rs
+++ b/h2datatype/src/simple/network/mac_address.rs
@@ -25,7 +25,7 @@ impl MacAddress {
 }
 
 impl H2TypeTrait for MacAddress {
-    fn base_size(&self, _context: Context) -> SimpleResult<u64> {
+    fn base_size(&self, _context: Context) -> SimpleResult<usize> {
         Ok(6)
     }
 

--- a/h2datatype/src/simple/network/mac_address8.rs
+++ b/h2datatype/src/simple/network/mac_address8.rs
@@ -25,7 +25,7 @@ impl MacAddress8 {
 }
 
 impl H2TypeTrait for MacAddress8 {
-    fn base_size(&self, _context: Context) -> SimpleResult<u64> {
+    fn base_size(&self, _context: Context) -> SimpleResult<usize> {
         Ok(8)
     }
 

--- a/h2datatype/src/simple/numeric/h2character.rs
+++ b/h2datatype/src/simple/numeric/h2character.rs
@@ -78,10 +78,10 @@ impl H2Character {
 }
 
 impl H2TypeTrait for H2Character {
-    fn base_size(&self, context: Context) -> SimpleResult<u64> {
+    fn base_size(&self, context: Context) -> SimpleResult<usize> {
         match self.reader.size() {
-            Some(v) => Ok(v as u64),
-            None    => Ok(self.reader.read(context)?.size() as u64),
+            Some(v) => Ok(v),
+            None    => Ok(self.reader.read(context)?.size()),
         }
     }
 

--- a/h2datatype/src/simple/numeric/h2float.rs
+++ b/h2datatype/src/simple/numeric/h2float.rs
@@ -38,8 +38,8 @@ impl H2Float {
 }
 
 impl H2TypeTrait for H2Float {
-    fn base_size(&self, _context: Context) -> SimpleResult<u64> {
-        Ok(self.reader.size() as u64)
+    fn base_size(&self, _context: Context) -> SimpleResult<usize> {
+        Ok(self.reader.size())
     }
 
     fn to_display(&self, context: Context) -> SimpleResult<String> {

--- a/h2datatype/src/simple/numeric/h2integer.rs
+++ b/h2datatype/src/simple/numeric/h2integer.rs
@@ -38,8 +38,8 @@ impl H2Integer {
 }
 
 impl H2TypeTrait for H2Integer {
-    fn base_size(&self, _context: Context) -> SimpleResult<u64> {
-        Ok(self.reader.size() as u64)
+    fn base_size(&self, _context: Context) -> SimpleResult<usize> {
+        Ok(self.reader.size())
     }
 
     fn to_display(&self, context: Context) -> SimpleResult<String> {
@@ -148,7 +148,7 @@ mod tests {
     }
 
     #[test]
-    fn test_to_i64() -> SimpleResult<()> {
+    fn test_to_isize() -> SimpleResult<()> {
         let data = b"\x00\x00\x7f\xff\x80\x00\xff\xff".to_vec();
         let context = Context::new(&data);
 
@@ -166,7 +166,7 @@ mod tests {
     }
 
     #[test]
-    fn test_to_u64() -> SimpleResult<()> {
+    fn test_to_usize() -> SimpleResult<()> {
         let data = b"\x00\x00\x7f\xff\x80\x00\xff\xff".to_vec();
         let context = Context::new(&data);
 

--- a/h2datatype/src/simple/rgb.rs
+++ b/h2datatype/src/simple/rgb.rs
@@ -31,7 +31,7 @@ impl Rgb {
 }
 
 impl H2TypeTrait for Rgb {
-    fn base_size(&self, _context: Context) -> SimpleResult<u64> {
+    fn base_size(&self, _context: Context) -> SimpleResult<usize> {
         Ok(3)
     }
 

--- a/h2datatype/src/simple/string/h2string.rs
+++ b/h2datatype/src/simple/string/h2string.rs
@@ -14,13 +14,13 @@ use crate::{H2Type, H2Types, H2TypeTrait, Alignment};
 /// types.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct H2String {
-    length: u64,
+    length: usize,
     character: CharacterReader,
     renderer: CharacterRenderer,
 }
 
 impl H2String {
-    pub fn new_aligned(alignment: Alignment, length_in_characters: u64, character: CharacterReader, renderer: CharacterRenderer) -> SimpleResult<H2Type> {
+    pub fn new_aligned(alignment: Alignment, length_in_characters: usize, character: CharacterReader, renderer: CharacterRenderer) -> SimpleResult<H2Type> {
         if length_in_characters == 0 {
             bail!("Length must be at least 1 character long");
         }
@@ -32,12 +32,12 @@ impl H2String {
         })))
     }
 
-    pub fn new(length_in_characters: u64, character: CharacterReader, renderer: CharacterRenderer) -> SimpleResult<H2Type> {
+    pub fn new(length_in_characters: usize, character: CharacterReader, renderer: CharacterRenderer) -> SimpleResult<H2Type> {
         Self::new_aligned(Alignment::None, length_in_characters, character, renderer)
     }
 
 
-    fn analyze(&self, context: Context) -> SimpleResult<(u64, Vec<Character>)> {
+    fn analyze(&self, context: Context) -> SimpleResult<(usize, Vec<Character>)> {
         let mut position = context.position();
         let mut result = Vec::new();
 
@@ -47,7 +47,7 @@ impl H2String {
             let this_character = self.character.read(this_context)?;
 
             result.push(this_character);
-            position = position + this_character.size() as u64;
+            position = position + this_character.size();
         }
 
         Ok((position - context.position(), result))
@@ -55,9 +55,9 @@ impl H2String {
 }
 
 impl H2TypeTrait for H2String {
-    fn base_size(&self, context: Context) -> SimpleResult<u64> {
+    fn base_size(&self, context: Context) -> SimpleResult<usize> {
         match self.character.size() {
-            Some(s) => Ok(s as u64 * self.length),
+            Some(s) => Ok(s * self.length),
             None => Ok(self.analyze(context)?.0),
         }
     }

--- a/h2datatype/src/simple/string/lpstring.rs
+++ b/h2datatype/src/simple/string/lpstring.rs
@@ -10,7 +10,7 @@ use crate::{H2Type, H2Types, H2TypeTrait, Alignment};
 ///
 /// This is a string with a numerical prefix that denotes the length of the
 /// string (in *characters*). The length is any numerical value as defined in
-/// [`generic_number::IntegerReader`] that `can_be_u64()`, and the
+/// [`generic_number::IntegerReader`] that `can_be_usize()`, and the
 /// character type is from [`generic_number::CharacterReader`].
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LPString {
@@ -36,17 +36,17 @@ impl LPString {
         Self::new_aligned(Alignment::None, length, character, renderer)
     }
 
-    fn analyze(&self, context: Context) -> SimpleResult<(u64, Vec<Character>)> {
+    fn analyze(&self, context: Context) -> SimpleResult<(usize, Vec<Character>)> {
         // TODO: This should be usize
         let length = self.length.read(context)?.as_usize()?;
-        let mut position = context.position() + self.length.size() as u64;
+        let mut position = context.position() + self.length.size();
 
         let mut result = Vec::new();
         for _ in 0..length {
             let character = self.character.read(context.at(position))?;
 
             result.push(character);
-            position = position + character.size() as u64;
+            position = position + character.size();
         }
 
         Ok((position - context.position(), result))
@@ -54,7 +54,7 @@ impl LPString {
 }
 
 impl H2TypeTrait for LPString {
-    fn base_size(&self, context: Context) -> SimpleResult<u64> {
+    fn base_size(&self, context: Context) -> SimpleResult<usize> {
         Ok(self.analyze(context)?.0)
     }
 

--- a/h2datatype/src/simple/string/lpstring.rs
+++ b/h2datatype/src/simple/string/lpstring.rs
@@ -37,7 +37,6 @@ impl LPString {
     }
 
     fn analyze(&self, context: Context) -> SimpleResult<(usize, Vec<Character>)> {
-        // TODO: This should be usize
         let length = self.length.read(context)?.as_usize()?;
         let mut position = context.position() + self.length.size();
 

--- a/h2datatype/src/simple/string/ntstring.rs
+++ b/h2datatype/src/simple/string/ntstring.rs
@@ -28,13 +28,13 @@ impl NTString {
         Self::new_aligned(Alignment::None, character, renderer)
     }
 
-    fn analyze(&self, offset: Context) -> SimpleResult<(u64, Vec<Character>)> {
+    fn analyze(&self, offset: Context) -> SimpleResult<(usize, Vec<Character>)> {
         let mut position = offset.position();
         let mut result = Vec::new();
 
         loop {
             let this_character = self.character.read(offset.at(position))?;
-            position = position + this_character.size() as u64;
+            position = position + this_character.size();
 
             if this_character.as_char() == '\0' {
                 break;
@@ -49,7 +49,7 @@ impl NTString {
 }
 
 impl H2TypeTrait for NTString {
-    fn base_size(&self, offset: Context) -> SimpleResult<u64> {
+    fn base_size(&self, offset: Context) -> SimpleResult<usize> {
         Ok(self.analyze(offset)?.0)
     }
 

--- a/h2gb/src/actions/entry_create.rs
+++ b/h2gb/src/actions/entry_create.rs
@@ -67,7 +67,7 @@ impl Command for ActionEntryCreate {
         self.0 = State::Backward(Backward {
             buffer: forward.buffer.clone(),
             layer: forward.layer.clone(),
-            offset: forward.resolved_type.actual_range.start as usize,
+            offset: forward.resolved_type.actual_range.start,
         });
 
         Ok(())

--- a/h2gb/src/analyzer/helpers.rs
+++ b/h2gb/src/analyzer/helpers.rs
@@ -20,7 +20,7 @@ pub fn commit_entry(record: &mut Record<Action>, buffer: &str, layer: &str, reso
 
     // Add a comment if one was given
     if let Some(c) = comment {
-        let comment_action = ActionEntrySetComment::new(buffer, layer, offset as usize, Some(c.to_string()));
+        let comment_action = ActionEntrySetComment::new(buffer, layer, offset, Some(c.to_string()));
         record.apply(comment_action)?;
     }
 
@@ -28,7 +28,7 @@ pub fn commit_entry(record: &mut Record<Action>, buffer: &str, layer: &str, reso
 }
 
 pub fn add_comment(record: &mut Record<Action>, buffer: &str, layer: &str, offset: usize, comment: &str) -> SimpleResult<()> {
-    record.apply(ActionEntrySetComment::new(buffer, layer, offset as usize, Some(comment.to_string())))
+    record.apply(ActionEntrySetComment::new(buffer, layer, offset, Some(comment.to_string())))
 }
 
 pub fn create_entry(record: &mut Record<Action>, buffer: &str, layer: &str, datatype: &H2Type, offset: usize, comment: Option<&str>) -> SimpleResult<ResolvedType> {
@@ -41,15 +41,15 @@ pub fn create_entry(record: &mut Record<Action>, buffer: &str, layer: &str, data
     Ok(resolved)
 }
 
-/// This is a helper function that creates a record, then returns it as a simple
-/// u64 - I found myself doing this a lot.
+/// This is a helper function that creates a record, then returns it as an
+/// [`Integer`] - I found myself doing this a lot.
 pub fn create_entry_integer(record: &mut Record<Action>, buffer: &str, layer: &str, datatype: &H2Type, offset: usize, comment: Option<&str>) -> SimpleResult<Integer> {
     if !datatype.can_be_integer() {
         bail!("Attempting to create a numeric entry from a non-numeric datatype");
     }
 
     create_entry(record, buffer, layer, datatype, offset, comment)?.as_integer.ok_or(
-        SimpleError::new("Could not create entry as a u64 value")
+        SimpleError::new("Could not create entry as an Integer value")
     ).map_err( |e| SimpleError::new(format!("Could not interpret entry as an integer: {:?}", e)))
 }
 

--- a/h2gb/src/analyzer/mod.rs
+++ b/h2gb/src/analyzer/mod.rs
@@ -439,7 +439,7 @@ fn parse_spawnpoints(record: &mut Record<Action>, buffer: &str, starting_offset:
         )?;
 
         // Update to the next spawn offset
-        current_spawn_offset = spawn_point.actual_range.end as usize;
+        current_spawn_offset = spawn_point.actual_range.end;
     }
 
     Ok(current_spawn_offset)
@@ -468,7 +468,7 @@ fn parse_journeymode(record: &mut Record<Action>, buffer: &str, starting_offset:
         )?;
 
         // Update to the next journey offset
-        current_journey_offset = journey_item.actual_range.end as usize;
+        current_journey_offset = journey_item.actual_range.end;
     }
 
     Ok(())
@@ -498,7 +498,7 @@ pub fn analyze_terraria(record: &mut Record<Action>, buffer: &str) -> SimpleResu
     let name = create_entry(record, buffer, LAYER, &*TERRARIA_LPSTRING, offsets.name, Some("Character name"))?;
 
     // The end of the name is the starting offset for the next bunch of fields
-    let base = name.actual_range.end as usize;
+    let base = name.actual_range.end;
 
     // Time played has a special parser because it's a duration value that we
     // want to display pretty

--- a/h2gb/src/project/h2buffer.rs
+++ b/h2gb/src/project/h2buffer.rs
@@ -75,7 +75,7 @@ impl fmt::Display for H2Buffer {
                     Ok(Some(entry)) => {
                         // Deal with the entry
                         let resolved = entry.resolved();
-                        let actual_range = (resolved.actual_range.start as usize)..(resolved.actual_range.end as usize);
+                        let actual_range = resolved.actual_range.start..resolved.actual_range.end;
 
                         let entry_byte_string: Vec<String> = self.data[actual_range.clone()].iter().take(self.context_bytes).map(|b| format!("{:02x}", b)).collect();
                         let entry_byte_string = entry_byte_string.join(" ");
@@ -97,7 +97,7 @@ impl fmt::Display for H2Buffer {
                         }
 
                         // Deal with the padding / alignment
-                        let alignment_range = (resolved.actual_range.end as usize)..(resolved.aligned_range.end as usize);
+                        let alignment_range = (resolved.actual_range.end)..(resolved.aligned_range.end);
                         if !alignment_range.is_empty() {
                             let alignment_byte_string: Vec<String> = self.data[alignment_range.clone()].iter().map(|b| format!("{:02x}", b)).collect();
                             let alignment_byte_string = alignment_byte_string.join(" ");
@@ -119,7 +119,7 @@ impl fmt::Display for H2Buffer {
                         }
 
                         // Move to the next entry
-                        offset = resolved.aligned_range.end as usize;
+                        offset = resolved.aligned_range.end;
                     },
                     Ok(None) => {
                         if self.display_empty_addresses {
@@ -438,7 +438,7 @@ impl H2Buffer {
     }
 
     pub fn peek(&self, abstract_type: &H2Type, offset: usize) -> SimpleResult<ResolvedType> {
-        let offset = Context::new_at(&self.data, offset as u64);
+        let offset = Context::new_at(&self.data, offset);
 
         abstract_type.resolve(offset, None)
     }

--- a/h2gb/src/project/h2entry.rs
+++ b/h2gb/src/project/h2entry.rs
@@ -24,8 +24,7 @@ impl fmt::Display for H2Entry {
 
 impl AutoBumpyEntry for H2Entry {
     fn range(&self) -> Range<usize> {
-        // TODO: Converting like this is bad news
-        (self.resolved_type.aligned_range.start as usize)..(self.resolved_type.aligned_range.end as usize)
+        self.resolved_type.aligned_range.start..self.resolved_type.aligned_range.end
     }
 }
 

--- a/h2transformation/src/lib.rs
+++ b/h2transformation/src/lib.rs
@@ -365,15 +365,15 @@ impl fmt::Display for Transformation {
 
 impl Transformation {
     fn get_transformer(&self) -> Box<dyn TransformerTrait> {
-        match self { // TODO: I think I can simplify this by moving the *
-            Self::Null(s)             => Box::new(*s),
-            Self::XorByConstant(s)    => Box::new(*s),
-            Self::FromBase64(s)       => Box::new(*s),
-            Self::FromBase32(s)       => Box::new(*s),
-            Self::FromDeflated(s)     => Box::new(*s),
-            Self::FromHex(s)          => Box::new(*s),
-            Self::FromBlockCipher(s)  => Box::new(*s),
-            Self::FromStreamCipher(s) => Box::new(*s),
+        match *self {
+            Self::Null(s)             => Box::new(s),
+            Self::XorByConstant(s)    => Box::new(s),
+            Self::FromBase64(s)       => Box::new(s),
+            Self::FromBase32(s)       => Box::new(s),
+            Self::FromDeflated(s)     => Box::new(s),
+            Self::FromHex(s)          => Box::new(s),
+            Self::FromBlockCipher(s)  => Box::new(s),
+            Self::FromStreamCipher(s) => Box::new(s),
         }
     }
 

--- a/h2transformation/src/transform/transform_stream_cipher.rs
+++ b/h2transformation/src/transform/transform_stream_cipher.rs
@@ -36,7 +36,7 @@ pub struct TransformStreamCipher {
     cipher: StreamCipherType,
     key: KeyOrIV,
     iv: Option<KeyOrIV>,
-    offset: u64,
+    offset: usize,
 }
 
 impl fmt::Display for TransformStreamCipher {


### PR DESCRIPTION
Internally, we've been using `usize` for some time. The problem is that it's downcast to `usize` whenever we access memory, and that's just gonna cause bugs.

This PR changes everything internally to use `usize` directly, which means it should be consistent (although will be kinda awkward on a 32-bit CPU). Most of the code was a 1:1 change, which is good news!

(PR #8 was the wrong branch, whoops!)